### PR TITLE
Ensure compatibility with latest stable Flutter version(`3.29.0`)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,8 +7,9 @@ buildscript {
         jcenter()
     }
 
+    ext.kotlin_version = '1.8.0'
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:7.2.2'
     }
 }
 
@@ -22,7 +23,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    namespace "me.wolszon.app_group_directory"
+    compileSdkVersion 35
 
     defaultConfig {
         minSdkVersion 16

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="me.wolszon.app_group_directory">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/android/src/main/java/me/wolszon/app_group_directory/AppGroupDirectoryPlugin.java
+++ b/android/src/main/java/me/wolszon/app_group_directory/AppGroupDirectoryPlugin.java
@@ -1,20 +1,20 @@
 package me.wolszon.app_group_directory;
 
 import androidx.annotation.NonNull;
-
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class AppGroupDirectoryPlugin implements FlutterPlugin, MethodCallHandler {
   private static final String CHANNEL_NAME = "me.wolszon.app_group_directory/channel";
+  private MethodChannel channel;
 
-  public static void registerWith(Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL_NAME);
-    channel.setMethodCallHandler(new AppGroupDirectoryPlugin());
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+    channel = new MethodChannel(binding.getBinaryMessenger(), CHANNEL_NAME);
+    channel.setMethodCallHandler(this);
   }
 
   @Override
@@ -23,11 +23,10 @@ public class AppGroupDirectoryPlugin implements FlutterPlugin, MethodCallHandler
   }
 
   @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
-    final MethodChannel channel = new MethodChannel(binding.getBinaryMessenger(), CHANNEL_NAME);
-    channel.setMethodCallHandler(new AppGroupDirectoryPlugin());
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    if (channel != null) {
+      channel.setMethodCallHandler(null);
+      channel = null;
+    }
   }
-
-  @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,8 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    namespace "me.wolszon.app_group_directory"
+    compileSdkVersion 35
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,7 +36,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.github.mingchen.flutter.plugins.ios_app_group_example"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -55,6 +56,7 @@ flutter {
 }
 
 dependencies {
+    implementation 'io.flutter:flutter_embedding:2.0.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,56 +7,55 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "3.0.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -67,87 +66,131 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.8"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.9"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.17"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.19"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.3.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/app_group_directory.dart
+++ b/lib/app_group_directory.dart
@@ -4,8 +4,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 
 class AppGroupDirectory {
-  static const _channel =
-      MethodChannel('me.wolszon.app_group_directory/channel');
+  static const MethodChannel _channel = MethodChannel('me.wolszon.app_group_directory/channel');
 
   /// Returns the container directory associated with the specified security
   /// application group identifier [groupId].
@@ -16,9 +15,8 @@ class AppGroupDirectory {
   /// Returns method not implemented on other platforms.
   ///
   /// See https://developer.apple.com/documentation/foundation/nsfilemanager/1412643-containerurlforsecurityapplicati
-  static Future<Directory?> getAppGroupDirectory(String groupId) async {
-    final path =
-        await _channel.invokeMethod<String>('getAppGroupDirectory', groupId);
+  Future<Directory?> getAppGroupDirectory(String groupId) async {
+    final path = await _channel.invokeMethod<String>('getAppGroupDirectory', groupId);
 
     if (path == null) {
       return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,12 +2,12 @@ name: app_group_directory
 description: >-
   Retrieve App Group directory on iOS.
   Port of FileManager.containerURL to Flutter.
-version: 2.0.0
+version: 3.0.0
 homepage: https://github.com/Albert221/app_group_directory
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lint: ^1.5.3
+  lint: ^2.6.1
 
 flutter:
   plugin:

--- a/test/app_group_directory_test.dart
+++ b/test/app_group_directory_test.dart
@@ -4,23 +4,29 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   const channel = MethodChannel('me.wolszon.app_group_directory/channel');
+  final defaultBinaryMessenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
 
-  setUp(
-    () {
-      TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
 
-      channel.setMockMethodCallHandler(
-        (_) async => '/private/var/mobile/Containers/Shared/'
-            'AppGroup/5CFF96C4-8B73-449F-99A3-F871D21862BD',
-      );
-    },
-  );
+    defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (methodCall) async {
+        if (methodCall.method == 'getAppGroupDirectory') {
+          return '/private/var/mobile/Containers/Shared/'
+              'AppGroup/5CFF96C4-8B73-449F-99A3-F871D21862BD';
+        }
+        return null;
+      },
+    );
+  });
 
-  tearDown(() => channel.setMockMethodCallHandler(null));
+  tearDown(() {
+    defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+  });
 
   test('getAppGroupDirectory', () async {
-    final dir =
-        await AppGroupDirectory.getAppGroupDirectory('com.example.app1');
+    final dir = await AppGroupDirectory().getAppGroupDirectory('com.example.app1');
 
     expect(
       dir?.path,


### PR DESCRIPTION
**Android**
* Migrate to Android embedding V2
* Define namespace in the module-level build script
* Update compileSdkVersion to 35
* Update Gradle to 7.2
* Remove package name from AndroidManifest.xml

**Flutter**
* Increase Dart & Flutter SDK range
* Update dependencies to latest
* Address linter warning: avoid_classes_with_only_static_members